### PR TITLE
default setting don't send optin mail

### DIFF
--- a/lib/embulk/output/mailchimp.rb
+++ b/lib/embulk/output/mailchimp.rb
@@ -30,7 +30,7 @@ module Embulk
         task = {
           apikey:                 config.param("apikey",                 :string),
           list_id:                config.param("list_id",                :string),
-          double_optin:           config.param("double_optin",           :bool,    default: true),
+          double_optin:           config.param("double_optin",           :bool,    default: false),
           update_existing:        config.param("update_existing",        :bool,    default: false),
           replace_interests:      config.param("replace_interests",      :bool,    default: true),
           email_column:           config.param("email_column",           :string,  default: "email"),


### PR DESCRIPTION
Because the default setting of batch processing is not preferable to
become a write a letter.
