### PR TITLE
Change the threshold of batch size for uploading emails as a request

### DIFF
--- a/lib/embulk/output/mailchimp.rb
+++ b/lib/embulk/output/mailchimp.rb
@@ -26,7 +26,7 @@ module Embulk
         end
       end
 
-      MAX_EMAIL_COUNT = 1_000_000
+      MAX_EMAIL_COUNT = 1_000
 
       def self.transaction(config, schema, count, &control)
         task = {


### PR DESCRIPTION
avoid timeout error.
