### PR TITLE
Enable double optin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.0.3 - 2016-05-18
+- Fixed bug can not extract data center when use `api_key` as `auth_mode` [#15](https://github.com/treasure-data/embulk-output-mailchimp/pull/15)
+
 ## 0.3.0.2 - 2016-05-18
 - Enabled double_optin in configuration and use default status if schema has no column `status` [#15](https://github.com/treasure-data/embulk-output-mailchimp/pull/15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.0.2 - 2016-05-18
+- Enabled double_optin in configuration and use default status if schema has no column `status` [#15](https://github.com/treasure-data/embulk-output-mailchimp/pull/15)
+
 ## 0.3.0.1 - 2016-05-11
 - Enabled API v3 and supported OAuth2 beside API Key[#13](https://github.com/treasure-data/embulk-output-mailchimp/pull/13)
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ configurations {
     provided
 }
 
-version = "0.3.0.2"
+version = "0.3.0.3"
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ configurations {
     provided
 }
 
-version = "0.3.0.1"
+version = "0.3.0.2"
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpAbstractRecordBuffer.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpAbstractRecordBuffer.java
@@ -48,7 +48,7 @@ public abstract class MailChimpAbstractRecordBuffer
     /**
      * The constant mailchimpEndpoint.
      */
-    protected static String mailchimpEndpoint = "https://us.api.mailchimp.com";
+    protected static String mailchimpEndpoint = "https://{0}.api.mailchimp.com/3.0";
     private final MailChimpOutputPluginDelegate.PluginTask task;
     private final ObjectMapper mapper;
     private final Schema schema;
@@ -151,7 +151,7 @@ public abstract class MailChimpAbstractRecordBuffer
     ObjectNode processSubcribers(final List<JsonNode> data, final MailChimpOutputPluginDelegate.PluginTask task)
     {
         LOG.info("Start to process subscriber data");
-        extractDataCenter();
+        extractDataCenterBasedOnAuthMethod();
         validateInterestCategories();
         validateMemberStatus(data);
 
@@ -263,12 +263,12 @@ public abstract class MailChimpAbstractRecordBuffer
     abstract String extractDataCenter(final MailChimpOutputPluginDelegate.PluginTask task)
             throws JsonProcessingException;
 
-    private void extractDataCenter()
+    private void extractDataCenterBasedOnAuthMethod()
     {
         try {
             // Extract data center from meta data URL
             String dc = extractDataCenter(task);
-            mailchimpEndpoint = MessageFormat.format("https://{0}.api.mailchimp.com", dc);
+            mailchimpEndpoint = MessageFormat.format(mailchimpEndpoint, dc);
         }
         catch (JsonProcessingException jpe) {
             throw new DataException(jpe);

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpHttpClient.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpHttpClient.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.google.common.base.Throwables;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
@@ -121,7 +120,7 @@ public class MailChimpHttpClient
                 return "OAuth " + task.getAccessToken().orNull();
             case API_KEY:
                 return "Basic " + Base64Variants.MIME_NO_LINEFEEDS
-                        .encode((RandomStringUtils.randomAlphabetic(10) + ":" + task.getApikey().orNull()).getBytes());
+                        .encode(("apikey" + ":" + task.getApikey().orNull()).getBytes());
             default:
                 throw new ConfigException("Not supported method");
         }

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
@@ -54,7 +54,7 @@ public class MailChimpOutputPluginDelegate
         int getTimeoutMillis();
 
         @Config("auth_method")
-        @ConfigDefault("access_token")
+        @ConfigDefault("api_key")
         AuthMethod getAuthMethod();
 
         @Config("apikey")

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
@@ -76,6 +76,10 @@ public class MailChimpOutputPluginDelegate
         @ConfigDefault("null")
         Optional<List<String>> getInterestCategories();
 
+        @Config("double_optin")
+        @ConfigDefault("false")
+        boolean getDoubleOptIn();
+
         @Config("update_existing")
         @ConfigDefault("false")
         boolean getUpdateExisting();
@@ -107,8 +111,8 @@ public class MailChimpOutputPluginDelegate
             throw new ConfigException("'list_id' must not be null or empty string");
         }
 
-        if (!checkExistColumns(schema, "email", "status")) {
-            throw new ConfigException("Columns ['email', 'status'] must not be null or empty string");
+        if (!checkExistColumns(schema, "email")) {
+            throw new ConfigException("Columns ['email'] must not be null or empty string");
         }
     }
 

--- a/src/main/java/org/embulk/output/mailchimp/validation/ColumnDataValidator.java
+++ b/src/main/java/org/embulk/output/mailchimp/validation/ColumnDataValidator.java
@@ -17,7 +17,7 @@ public final class ColumnDataValidator
     }
 
     /**
-     * Check required columns. In contact target, should require `email` and `status` columns
+     * Check required columns. Should require `email` and `status` columns
      *
      * @param schema       the schema
      * @param allowColumns the columns

--- a/src/test/java/org/embulk/output/mailchimp/TestMailChimpOutputPlugin.java
+++ b/src/test/java/org/embulk/output/mailchimp/TestMailChimpOutputPlugin.java
@@ -115,22 +115,6 @@ public class TestMailChimpOutputPlugin
         plugin.transaction(config, schema, 0, new OutputControl());
     }
 
-    @Test(expected = ConfigException.class)
-    public void test_config_invalidWithColumnStatusRequires()
-    {
-        ConfigSource config = baseConfig;
-        Schema schema = Schema.builder()
-                .add("email", STRING)
-                .add("fname", STRING)
-                .add("lname", STRING)
-                .build();
-
-        final TransactionalPageOutput output = plugin.open(task.dump(), schema, 0);
-        output.finish();
-
-        plugin.transaction(config, schema, 0, new OutputControl());
-    }
-
     /**
      * Load plugin config with Guava & Joda support
      */


### PR DESCRIPTION
- Follows PR https://github.com/treasure-data/embulk-output-mailchimp/pull/13
- Restore `double_optin` from configuration
- Use default `status` with `double_optin` if schema has no column `status`
- Use data center info extract from metadata url