### PR TITLE
Fixed JSON format in MERGE field's type is address

### DIFF
--- a/src/main/java/org/embulk/output/mailchimp/MailChimpAbstractRecordBuffer.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpAbstractRecordBuffer.java
@@ -15,6 +15,7 @@ import org.embulk.base.restclient.jackson.JacksonServiceRecord;
 import org.embulk.base.restclient.record.RecordBuffer;
 import org.embulk.base.restclient.record.ServiceRecord;
 import org.embulk.config.TaskReport;
+import org.embulk.output.mailchimp.model.AddressMergeFieldAttribute;
 import org.embulk.output.mailchimp.model.ErrorResponse;
 import org.embulk.output.mailchimp.model.InterestResponse;
 import org.embulk.output.mailchimp.model.MergeField;
@@ -34,6 +35,7 @@ import java.util.Map;
 
 import static org.embulk.output.mailchimp.helper.MailChimpHelper.containsCaseInsensitive;
 import static org.embulk.output.mailchimp.helper.MailChimpHelper.fromCommaSeparatedString;
+import static org.embulk.output.mailchimp.helper.MailChimpHelper.orderJsonNode;
 import static org.embulk.output.mailchimp.helper.MailChimpHelper.toJsonNode;
 import static org.embulk.output.mailchimp.model.MemberStatus.PENDING;
 import static org.embulk.output.mailchimp.model.MemberStatus.SUBSCRIBED;
@@ -281,7 +283,8 @@ public abstract class MailChimpAbstractRecordBuffer
                                     mergeFields.put(column.getName().toUpperCase(), value);
                                 }
                                 else {
-                                    mergeFields.set(column.getName().toUpperCase(), addressNode);
+                                    mergeFields.set(column.getName().toUpperCase(),
+                                                    orderJsonNode(addressNode, AddressMergeFieldAttribute.values()));
                                 }
                             }
                             else {

--- a/src/main/java/org/embulk/output/mailchimp/helper/MailChimpHelper.java
+++ b/src/main/java/org/embulk/output/mailchimp/helper/MailChimpHelper.java
@@ -5,11 +5,13 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
+import org.embulk.output.mailchimp.model.AddressMergeFieldAttribute;
 
 import javax.annotation.Nullable;
 
@@ -104,5 +106,24 @@ public final class MailChimpHelper
         catch (IOException e) {
             return JsonNodeFactory.instance.nullNode();
         }
+    }
+
+    /**
+     * MailChimp API requires MERGE field's type is address that have to json with keys in order.
+     * {"addr1": "a", "addr2": "a1", "city": "c", "state": "s", "zip": "z", "country": "c"}
+     *
+     * @param originalNode the original node
+     * @param attrsInOrder the keys in order
+     * @return the object node
+     */
+    public static ObjectNode orderJsonNode(final JsonNode originalNode, final AddressMergeFieldAttribute[] attrsInOrder)
+    {
+        ObjectNode orderedNode = JsonNodeFactory.instance.objectNode();
+        for (AddressMergeFieldAttribute attr : attrsInOrder) {
+            orderedNode.put(attr.getName(),
+                            originalNode.findValue(attr.getName()) != null ? originalNode.findValue(attr.getName()).asText() : "");
+        }
+
+        return orderedNode;
     }
 }

--- a/src/main/java/org/embulk/output/mailchimp/model/AddressMergeFieldAttribute.java
+++ b/src/main/java/org/embulk/output/mailchimp/model/AddressMergeFieldAttribute.java
@@ -1,0 +1,49 @@
+package org.embulk.output.mailchimp.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import org.embulk.config.ConfigException;
+
+/**
+ * Created by thangnc on 6/9/17.
+ */
+public enum AddressMergeFieldAttribute
+{
+    ADDR1("addr1"), ADDR2("addr2"), CITY("city"), STATE("state"), ZIP("zip"), COUNTRY("country");
+
+    private String name;
+
+    AddressMergeFieldAttribute(String type)
+    {
+        this.name = type;
+    }
+
+    /**
+     * Gets name.
+     *
+     * @return the name
+     */
+    public String getName()
+    {
+        return name;
+    }
+
+    /**
+     * Find by name method.
+     *
+     * @param name the name
+     * @return the auth method
+     */
+    @JsonCreator
+    public static AddressMergeFieldAttribute findByName(final String name)
+    {
+        for (AddressMergeFieldAttribute method : values()) {
+            if (method.getName().equals(name.toLowerCase())) {
+                return method;
+            }
+        }
+
+        throw new ConfigException(
+                String.format("Unknown attributes '%s'. Supported attributes are [addr1, addr1, state, zip, country]",
+                              name));
+    }
+}

--- a/src/test/java/org/embulk/output/mailchimp/TestMailChimpHelper.java
+++ b/src/test/java/org/embulk/output/mailchimp/TestMailChimpHelper.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Multimap;
 import org.embulk.output.mailchimp.helper.MailChimpHelper;
+import org.embulk.output.mailchimp.model.AddressMergeFieldAttribute;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -15,6 +16,7 @@ import java.util.List;
 import static org.embulk.output.mailchimp.helper.MailChimpHelper.containsCaseInsensitive;
 import static org.embulk.output.mailchimp.helper.MailChimpHelper.extractMemberStatus;
 import static org.embulk.output.mailchimp.helper.MailChimpHelper.maskEmail;
+import static org.embulk.output.mailchimp.helper.MailChimpHelper.orderJsonNode;
 import static org.embulk.output.mailchimp.helper.MailChimpHelper.toJsonNode;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -81,5 +83,16 @@ public class TestMailChimpHelper
     public void test_toJsonNode_invalidJSonString()
     {
         assertEquals("Should be NullNode", NullNode.class, toJsonNode("abc").getClass());
+    }
+
+    @Test
+    public void test_orderJsonNode()
+    {
+        String given = "{\"addr1\":\"1234\",\"city\":\"mountain view\",\"country\":\"US\",\"state\":\"CA\",\"zip\":\"95869\"}";
+        AddressMergeFieldAttribute[] attributes = AddressMergeFieldAttribute.values();
+
+        String expect = "{\"addr1\":\"1234\",\"addr2\":\"\",\"city\":\"mountain view\",\"state\":\"CA\",\"zip\":\"95869\",\"country\":\"US\"}";
+        assertEquals("Should be JSON", ObjectNode.class, orderJsonNode(toJsonNode(given), attributes).getClass());
+        assertEquals("Should be match", expect, orderJsonNode(toJsonNode(given), attributes).toString());
     }
 }


### PR DESCRIPTION
- MailChimp API requires MERGE field's type is address that have json with keys in order.
```
{"addr1": "a", "addr2": "a1", "city": "c", "state": "s", "zip": "z", "country": "c"}
```

- Added `AddressMergeFieldType`
- Added helper to fix order attributes of MERGE field's type is address before pushing data to MailChimp API
