### PR TITLE
Upgraded version of embulk-base-restclient to fix IndexOutOfBoundException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ targetCompatibility = 1.7
 dependencies {
     compile  "org.embulk:embulk-core:0.8.15"
     provided "org.embulk:embulk-core:0.8.15"
-    compile  "org.embulk.base.restclient:embulk-base-restclient:0.5.0"
-    compile  "org.embulk.base.restclient:embulk-util-retryhelper-jetty92:0.5.0"
+    compile  "org.embulk.base.restclient:embulk-base-restclient:0.5.2"
+    compile  "org.embulk.base.restclient:embulk-util-retryhelper-jetty92:0.5.2"
     // compile "YOUR_JAR_DEPENDENCY_GROUP:YOUR_JAR_DEPENDENCY_MODULE:YOUR_JAR_DEPENDENCY_VERSION"
 
     testCompile "junit:junit:4.+"


### PR DESCRIPTION
- Upgrade version of `embulk-base-restclient` to v0.5.2