### PR TITLE
Use host addon and set `dist` option to avoid CI failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
+dist: precise
 language: java
 jdk:
   - openjdk7
 script:
   - ./gradlew clean checkstyle check jacocoTestReport
+addons:
+  hosts:
+    - example
+  hostname: example


### PR DESCRIPTION
CI for recent PR is failing due to `javax.net.ssl.SSLException: java.security.ProviderException`
https://travis-ci.org/treasure-data/embulk-output-mailchimp/builds/274557748

Ubuntu version which we used before was automatically updated from **Ubuntu 12.04(precise)** to **14.04(Trusty)** and this caused CI failure.
https://blog.travis-ci.com/2017-08-31-trusty-as-default-status

I changes .travis.yml to avoid this problem.
* Set `dist` option
* Use host addon
  https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913