### PR TITLE
Fix error parsing MailChimp API response JSON when push the large data

### DIFF
--- a/src/main/java/org/embulk/output/mailchimp/MailChimpHttpClient.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpHttpClient.java
@@ -1,6 +1,8 @@
 package org.embulk.output.mailchimp;
 
 import com.fasterxml.jackson.core.Base64Variants;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.MissingNode;
@@ -31,8 +33,8 @@ public class MailChimpHttpClient
 {
     private static final Logger LOG = Exec.getLogger(MailChimpHttpClient.class);
     private final ObjectMapper jsonMapper = new ObjectMapper()
-            .configure(com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, false)
-            .configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            .configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, false)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     /**
      * Instantiates a new Mailchimp http client.

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
@@ -103,6 +103,10 @@ public class MailChimpOutputPluginDelegate
         @Config("language_column")
         @ConfigDefault("null")
         Optional<String> getLanguageColumn();
+
+        @Config("max_records_per_request")
+        @ConfigDefault("500")
+        int getMaxRecordsPerRequest();
     }
 
     /**

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
@@ -46,8 +46,6 @@ public class MailChimpRecordBuffer
         extends RecordBuffer
 {
     private static final Logger LOG = Exec.getLogger(MailChimpRecordBuffer.class);
-    // MailChimp enables max record per batch request about 500, but need to descrease to avoid MailChimp API error servers
-    private static final int MAX_RECORD_PER_BATCH_REQUEST = 100;
     private final MailChimpOutputPluginDelegate.PluginTask task;
     private final MailChimpClient mailChimpClient;
     private final ObjectMapper mapper;
@@ -89,7 +87,7 @@ public class MailChimpRecordBuffer
             totalCount++;
 
             records.add(record);
-            if (requestCount >= MAX_RECORD_PER_BATCH_REQUEST) {
+            if (requestCount >= task.getMaxRecordsPerRequest()) {
                 ObjectNode subcribers = processSubcribers(records, task);
                 ReportResponse reportResponse = mailChimpClient.push(subcribers, task);
 

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
@@ -46,7 +46,8 @@ public class MailChimpRecordBuffer
         extends RecordBuffer
 {
     private static final Logger LOG = Exec.getLogger(MailChimpRecordBuffer.class);
-    private static final int MAX_RECORD_PER_BATCH_REQUEST = 500;
+    // MailChimp enables max record per batch request about 500, but need to descrease to avoid MailChimp API error servers
+    private static final int MAX_RECORD_PER_BATCH_REQUEST = 100;
     private final MailChimpOutputPluginDelegate.PluginTask task;
     private final MailChimpClient mailChimpClient;
     private final ObjectMapper mapper;


### PR DESCRIPTION
## CHANGES
- With a large data, MailChimp API return response that can not parse. Then we got exception like this 
```
org.embulk.exec.PartialExecutionException: org.embulk.spi.DataException: com.fasterxml.jackson.core.JsonParseException: Unexpected character ('n' (code 110)): was expecting comma to separate OBJECT entries
```

- This PR will add 1 more configuration `max_records_per_request` to reduce the records per batch request. MailChimp enables default 500 but better we can reduce to 250-300 to avoid above exception