### PR TITLE
Fixed duplicated emails in payload

### DIFF
--- a/src/main/java/org/embulk/output/mailchimp/MailChimpClient.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpClient.java
@@ -82,7 +82,7 @@ public class MailChimpClient
                                                task.getListId());
 
         JsonNode response = client.sendRequest(endpoint, HttpMethod.POST, node.toString(), task);
-        client.avoidFlushAPI("Pushing next request");
+        client.avoidFlushAPI("Process next request");
 
         if (response instanceof MissingNode) {
             ReportResponse reportResponse = new ReportResponse();

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
@@ -305,6 +305,7 @@ public class MailChimpRecordBuffer
         if (duplicatedRecords.size() > 0) {
             LOG.info("Start to process {} duplicated record(s)", duplicatedRecords.size());
             for (JsonNode duplicatedRecord : duplicatedRecords) {
+                startTime = System.currentTimeMillis();
                 subscribers = processSubcribers(Arrays.asList(duplicatedRecord), task);
                 reportResponse = mailChimpClient.push(subscribers, task);
 

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
@@ -95,10 +95,8 @@ public class MailChimpRecordBuffer
 
             records.add(record);
             if (requestCount >= task.getMaxRecordsPerRequest()) {
-                long startTime = System.currentTimeMillis();
-
                 filterDuplicatedRecords();
-                pushData(startTime);
+                pushData();
 
                 if (totalCount % 1000 == 0) {
                     LOG.info("Pushed {} records", totalCount);
@@ -126,9 +124,8 @@ public class MailChimpRecordBuffer
     {
         try {
             if (records.size() > 0) {
-                long startTime = System.currentTimeMillis();
                 filterDuplicatedRecords();
-                pushData(startTime);
+                pushData();
                 records = new ArrayList<>();
                 uniqueRecords = new ArrayList<>();
                 duplicatedRecords = new ArrayList<>();
@@ -293,8 +290,9 @@ public class MailChimpRecordBuffer
         }
     }
 
-    private void pushData(final long startTime) throws JsonProcessingException
+    private void pushData() throws JsonProcessingException
     {
+        long startTime = System.currentTimeMillis();
         ObjectNode subscribers = processSubcribers(uniqueRecords, task);
         ReportResponse reportResponse = mailChimpClient.push(subscribers, task);
 

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
@@ -311,7 +311,7 @@ public class MailChimpRecordBuffer
                 reportResponse = mailChimpClient.push(subscribers, task);
 
                 LOG.info("Done. Response from MailChimp: {} records created, {} records updated, {} records failed. Batch took {} ms ",
-                         1, reportResponse.getTotalCreated(),
+                         reportResponse.getTotalCreated(),
                          reportResponse.getTotalUpdated(),
                          reportResponse.getErrorCount(), System.currentTimeMillis() - startTime);
                 mailChimpClient.handleErrors(reportResponse.getErrors());


### PR DESCRIPTION
## CHANGES
- With the large data, there are duplicated emails in the payload data. This will lead to the bad request error from MailChimp `Duplicate items found for email abc@xyz.com, please provide unique email address per member item`
- This PR fixed above error and did some refactor 