### PR TITLE
Refactor check list_id to avoid confusing when get 404 error

### DIFF
--- a/src/main/java/org/embulk/output/mailchimp/MailChimpHttpClient.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpHttpClient.java
@@ -86,8 +86,7 @@ public class MailChimpHttpClient
                             int status = response.getStatus();
 
                             if (status == 404) {
-                                LOG.error("Exception occurred while sending request: {}", response.getReason());
-                                throw new ConfigException("The `list id` could not be found.");
+                                LOG.error("The requested resource could not be found.");
                             }
 
                             return status == 429 || status / 100 != 4;

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpHttpClient.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpHttpClient.java
@@ -85,16 +85,13 @@ public class MailChimpHttpClient
                         {
                             int status = response.getStatus();
 
-                            if (status == 404) {
-                                LOG.error("The requested resource could not be found.");
-                            }
-
                             return status == 429 || status / 100 != 4;
                         }
 
                         @Override
                         protected boolean isExceptionToRetry(Exception exception)
                         {
+                            LOG.error("Exception to retry.", exception);
                             // This check is to make sure the exception is retryable, e.g: server not found, internal server error...
                             if (exception instanceof ConfigException || exception instanceof ExecutionException) {
                                 return toRetry((Exception) exception.getCause());
@@ -107,7 +104,7 @@ public class MailChimpHttpClient
             return responseBody != null && !responseBody.isEmpty() ? parseJson(responseBody) : MissingNode.getInstance();
         }
         catch (Exception ex) {
-            LOG.info("Exception occurred while sending request.");
+            LOG.error("Exception occurred while sending request.", ex);
             throw Throwables.propagate(ex);
         }
     }


### PR DESCRIPTION
## CHANGES
- This PR will call the checking `list_id` right after authentication with `extractDataCenter`. This avoid confusing when get 404 error