### PR TITLE
Fixed NPE when checking interest categories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ configurations {
     provided
 }
 
-version = "0.3.21"
+version = "0.3.22.alpha.1"
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
@@ -75,7 +75,6 @@ public class MailChimpRecordBuffer
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, false);
         this.records = new ArrayList<>();
-        this.categories = new HashMap<>();
         this.uniqueRecords = new ArrayList<>();
         this.duplicatedRecords = new ArrayList<>();
         this.mailChimpClient = new MailChimpClient(task);


### PR DESCRIPTION
## CHANGES
- This PR will fixed the bug NPE in #40 after doing refactor but should not initialize the map `categories` because we have check null at https://github.com/treasure-data/embulk-output-mailchimp/pull/40/files#diff-5dd4e665f9c2ba8bfdfcefd12be11b25R168