### PR TITLE
Support native EmbulkResult JSON type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: precise
 language: java
 jdk:
-  - openjdk8
+  - oraclejdk8
 script:
   - ./gradlew clean checkstyle check jacocoTestReport
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: precise
 language: java
 jdk:
-  - openjdk7
+  - openjdk8
 script:
   - ./gradlew clean checkstyle check jacocoTestReport
 addons:

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.jfrog.bintray" version "1.7.3"
+    id "com.jfrog.bintray" version "1.8.4"
     id "com.github.jruby-gradle.base" version "0.1.5"
     id "java"
     id "checkstyle"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.jfrog.bintray" version "1.8.4"
+    id "com.jfrog.bintray" version "1.7.3"
     id "com.github.jruby-gradle.base" version "0.1.5"
     id "java"
     id "checkstyle"

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ configurations {
     provided
 }
 
-version = "0.3.22"
+version = "0.3.23"
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Function;
 import com.google.common.base.Throwables;
@@ -38,7 +37,6 @@ import static org.embulk.output.mailchimp.MailChimpOutputPluginDelegate.PluginTa
 import static org.embulk.output.mailchimp.helper.MailChimpHelper.containsCaseInsensitive;
 import static org.embulk.output.mailchimp.helper.MailChimpHelper.fromCommaSeparatedString;
 import static org.embulk.output.mailchimp.helper.MailChimpHelper.orderJsonNode;
-import static org.embulk.output.mailchimp.helper.MailChimpHelper.toJsonNode;
 import static org.embulk.output.mailchimp.model.MemberStatus.PENDING;
 import static org.embulk.output.mailchimp.model.MemberStatus.SUBSCRIBED;
 
@@ -210,17 +208,10 @@ public class MailChimpRecordBuffer
                         if (!"".equals(containsCaseInsensitive(column.getName(), task.getMergeFields().get()))) {
                             String value = input.hasNonNull(column.getName()) ? input.findValue(column.getName()).asText() : "";
 
-                            // Try to convert to Json from string with the merge field's type is address
-                            if (availableMergeFields.get(column.getName().toLowerCase()).getType()
+                            if (availableMergeFields.get(column.getName().toLowerCase()) != null && availableMergeFields.get(column.getName().toLowerCase()).getType()
                                     .equals(MergeField.MergeFieldType.ADDRESS.getType())) {
-                                JsonNode addressNode = toJsonNode(value);
-                                if (addressNode instanceof NullNode) {
-                                    mergeFields.put(column.getName().toUpperCase(), value);
-                                }
-                                else {
-                                    mergeFields.set(column.getName().toUpperCase(),
-                                                    orderJsonNode(addressNode, AddressMergeFieldAttribute.values()));
-                                }
+                                mergeFields.set(column.getName().toUpperCase(),
+                                        orderJsonNode(input.findValue(column.getName()), AddressMergeFieldAttribute.values()));
                             }
                             else {
                                 mergeFields.put(column.getName().toUpperCase(), value);

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
@@ -208,7 +208,7 @@ public class MailChimpRecordBuffer
                         if (!"".equals(containsCaseInsensitive(column.getName(), task.getMergeFields().get()))) {
                             String value = input.hasNonNull(column.getName()) ? input.findValue(column.getName()).asText() : "";
 
-                            if (availableMergeFields.get(column.getName().toLowerCase()) != null && availableMergeFields.get(column.getName().toLowerCase()).getType()
+                            if (availableMergeFields.containsKey(column.getName().toLowerCase()) && availableMergeFields.get(column.getName().toLowerCase()).getType()
                                     .equals(MergeField.MergeFieldType.ADDRESS.getType())) {
                                 mergeFields.set(column.getName().toUpperCase(),
                                         orderJsonNode(input.findValue(column.getName()), AddressMergeFieldAttribute.values()));

--- a/src/main/java/org/embulk/output/mailchimp/helper/MailChimpHelper.java
+++ b/src/main/java/org/embulk/output/mailchimp/helper/MailChimpHelper.java
@@ -1,9 +1,6 @@
 package org.embulk.output.mailchimp.helper;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Function;
@@ -15,7 +12,6 @@ import org.embulk.output.mailchimp.model.AddressMergeFieldAttribute;
 
 import javax.annotation.Nullable;
 
-import java.io.IOException;
 import java.util.List;
 
 /**
@@ -87,25 +83,6 @@ public final class MailChimpHelper
     {
         Iterable<String> split = Splitter.on(",").omitEmptyStrings().trimResults().split(string);
         return Lists.newArrayList(split);
-    }
-
-    /**
-     * TODO: td-worker automatically converts Presto json type to Embulk string type. This is wordaround to convert String to JsonNode
-     *
-     * @param string the string
-     * @return the json node
-     */
-    public static JsonNode toJsonNode(final String string)
-    {
-        final ObjectMapper mapper = new ObjectMapper()
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                .configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, false);
-        try {
-            return mapper.readTree(string);
-        }
-        catch (IOException e) {
-            return JsonNodeFactory.instance.nullNode();
-        }
     }
 
     /**

--- a/src/test/java/org/embulk/output/mailchimp/TestMailChimpHelper.java
+++ b/src/test/java/org/embulk/output/mailchimp/TestMailChimpHelper.java
@@ -2,7 +2,6 @@ package org.embulk.output.mailchimp;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Multimap;
 import org.embulk.output.mailchimp.helper.MailChimpHelper;
@@ -17,7 +16,6 @@ import static org.embulk.output.mailchimp.helper.MailChimpHelper.containsCaseIns
 import static org.embulk.output.mailchimp.helper.MailChimpHelper.extractMemberStatus;
 import static org.embulk.output.mailchimp.helper.MailChimpHelper.maskEmail;
 import static org.embulk.output.mailchimp.helper.MailChimpHelper.orderJsonNode;
-import static org.embulk.output.mailchimp.helper.MailChimpHelper.toJsonNode;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -70,29 +68,18 @@ public class TestMailChimpHelper
     }
 
     @Test
-    public void test_toJsonNode_validJsonString()
+    public void test_orderJsonNodeForJsonColumn()
     {
-        String given = "{\"addr1\":\"1234\",\"city\":\"mountain view\",\"country\":\"US\",\"state\":\"CA\",\"zip\":\"95869\"}";
-        String expect = "US";
-
-        assertEquals("Should be Json", ObjectNode.class, toJsonNode(given).getClass());
-        assertEquals("Should have attribute `country`", expect, toJsonNode(given).get("country").asText());
-    }
-
-    @Test
-    public void test_toJsonNode_invalidJSonString()
-    {
-        assertEquals("Should be NullNode", NullNode.class, toJsonNode("abc").getClass());
-    }
-
-    @Test
-    public void test_orderJsonNode()
-    {
-        String given = "{\"addr1\":\"1234\",\"city\":\"mountain view\",\"country\":\"US\",\"state\":\"CA\",\"zip\":\"95869\"}";
+        ObjectNode given = JsonNodeFactory.instance.objectNode();
+        given.put("state", "CA");
+        given.put("addr1", "1234");
+        given.put("city", "mountain view");
+        given.put("country", "US");
+        given.put("zip", "95869");
         AddressMergeFieldAttribute[] attributes = AddressMergeFieldAttribute.values();
 
         String expect = "{\"addr1\":\"1234\",\"addr2\":\"\",\"city\":\"mountain view\",\"state\":\"CA\",\"zip\":\"95869\",\"country\":\"US\"}";
-        assertEquals("Should be JSON", ObjectNode.class, orderJsonNode(toJsonNode(given), attributes).getClass());
-        assertEquals("Should be match", expect, orderJsonNode(toJsonNode(given), attributes).toString());
+        assertEquals("Should be JSON", ObjectNode.class, orderJsonNode(given, attributes).getClass());
+        assertEquals("Should be match", expect, orderJsonNode(given, attributes).toString());
     }
 }


### PR DESCRIPTION
 Context : 

- Current :
td-worker converts Presto json type to Embulk string type. The plugin applies a workaround to convert String to JsonNode. 

- Now : When PLT-10126 is completed, the plugin will retrieve the Json type instead of string type, the update will receive the Json type as it is. Since the query containing Json column is not using by any customer, so it safely to remove the codes which parses serialized JSON string to Json object.

 Also , this PR fix null exception, when there's no address merge field configured in Mailchimp.