### PR TITLE
Add atomic upsert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: precise
 language: java
 jdk:
-  - openjdk8
+  - oraclejdk8
 script:
   - ./gradlew clean checkstyle check jacocoTestReport
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: precise
 language: java
 jdk:
-  - openjdk7
+  - openjdk8
 script:
   - ./gradlew clean checkstyle check jacocoTestReport
 addons:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.23 - 2018-09-12
+- Introduce an option to fail the job when there is an error returning from Mailchimp. Previous versions marked the job as success with
+detail error in log
 ## 0.3.22 - 2018-03-07
 - Fixed bug NPE when checking interest categories [#41](https://github.com/treasure-data/embulk-output-mailchimp/pull/41)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ add e-mail to List in MailChimp.
 - **grouping_columns**: Array for group names in MailChimp dashboard(array, default: nil)
 - **language_column**: column name for language (string, optional, default: nil)
 - **double_optin**: control whether to send an opt-in confirmation email (boolean, default: true)
+- **atomic_upsert** : Control the atomicity for the job. Job will be marked as success only when there is no error from Mailchimp. Default as false.
 - **max_records_per_request**: The max records per batch request. MailChimp API enables max records is 500 per batch request (int, default: 500)
 - **sleep_between_requests_millis**: The time to sleep between requests to avoid flood MailChimp API (int, default: 3000)
 
@@ -38,6 +39,7 @@ out:
   list_id: 'XXXXXXXXXX'
   update_existing: false
   double_optin: false
+  atomic_upsert: false
   email_column: e-mail
   fname_column: first name
   lname_column: lname

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ configurations {
     provided
 }
 
-version = "0.3.22"
+version = "0.3.23"
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
@@ -96,6 +96,10 @@ public class MailChimpOutputPluginDelegate
         @ConfigDefault("false")
         boolean getUpdateExisting();
 
+        @Config("atomic_upsert")
+        @ConfigDefault("false")
+        boolean getAtomicUpsert();
+
         @Config("replace_interests")
         @ConfigDefault("true")
         boolean getReplaceInterests();

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
@@ -185,14 +185,12 @@ public class MailChimpOutputPluginDelegate
                 totalError += taskReport.get(Integer.class, "error_count");
             }
         }
+        LOG.info("Pushed completed. {} records", totalInserted);
         // When atomic upsert is true, client expects all records are done properly.
         if (task.getAtomicUpsert() & totalError > 0) {
             LOG.info("Job requires atomic operation for all records. And there were {} errors in processing => Error as job's status", totalError);
             throw Throwables.propagate(new DataException("Some records are not properly processed at MailChimp. See log for detail"));
         }
-
-        LOG.info("Pushed completed. {} records", totalInserted);
-
         return Exec.newConfigDiff();
     }
 }

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
@@ -150,6 +150,10 @@ public class MailChimpOutputPluginDelegate
         if (!checkExistColumns(schema, task.getEmailColumn(), task.getFnameColumn(), task.getLnameColumn())) {
             throw new ConfigException("Columns ['email', 'fname', 'lname'] must not be null or empty string");
         }
+        if (task.getAtomicUpsert())
+        {
+            LOG.info(" Treating upsert as atomic operation");
+        }
     }
 
     @Override

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
@@ -150,8 +150,7 @@ public class MailChimpOutputPluginDelegate
         if (!checkExistColumns(schema, task.getEmailColumn(), task.getFnameColumn(), task.getLnameColumn())) {
             throw new ConfigException("Columns ['email', 'fname', 'lname'] must not be null or empty string");
         }
-        if (task.getAtomicUpsert())
-        {
+        if (task.getAtomicUpsert()) {
             LOG.info(" Treating upsert as atomic operation");
         }
     }

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
@@ -187,7 +187,7 @@ public class MailChimpOutputPluginDelegate
         }
         LOG.info("Pushed completed. {} records", totalInserted);
         // When atomic upsert is true, client expects all records are done properly.
-        if (task.getAtomicUpsert() & totalError > 0) {
+        if (task.getAtomicUpsert() && totalError > 0) {
             LOG.info("Job requires atomic operation for all records. And there were {} errors in processing => Error as job's status", totalError);
             throw Throwables.propagate(new DataException("Some records are not properly processed at MailChimp. See log for detail"));
         }

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
@@ -133,7 +133,7 @@ public class MailChimpRecordBuffer
             // When atomic upsert is true, client expects all records are done properly.
             if(task.getAtomicUpsert() && errorCount > 0)
             {
-                LOG.info("Job requires atomic operation for all records. And there was error in processing => Error as status");
+                LOG.info("Job requires atomic operation for all records. And there were {} errors in processing => Error as job's status", errorCount);
                 throw Throwables.propagate(new DataException("Some records are not properly processed at MailChimp. See log for detail"));
             }
             return Exec.newTaskReport().set("pushed", totalCount);

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
@@ -130,12 +130,7 @@ public class MailChimpRecordBuffer
                 uniqueRecords = new ArrayList<>();
                 duplicatedRecords = new ArrayList<>();
             }
-            // When atomic upsert is true, client expects all records are done properly.
-            if (task.getAtomicUpsert() && errorCount > 0) {
-                LOG.info("Job requires atomic operation for all records. And there were {} errors in processing => Error as job's status", errorCount);
-                throw Throwables.propagate(new DataException("Some records are not properly processed at MailChimp. See log for detail"));
-            }
-            return Exec.newTaskReport().set("pushed", totalCount);
+            return Exec.newTaskReport().set("pushed", totalCount).set("error_count", errorCount);
         }
         catch (JsonProcessingException jpe) {
             throw new DataException(jpe);

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
@@ -54,6 +54,7 @@ public class MailChimpRecordBuffer
     private final ObjectMapper mapper;
     private final Schema schema;
     private int requestCount;
+    private int errorCount;
     private long totalCount;
     private List<JsonNode> records;
     private Map<String, Map<String, InterestResponse>> categories;
@@ -129,7 +130,12 @@ public class MailChimpRecordBuffer
                 uniqueRecords = new ArrayList<>();
                 duplicatedRecords = new ArrayList<>();
             }
-
+            // When atomic upsert is true, client expects all records are done properly.
+            if(task.getAtomicUpsert() && errorCount > 0)
+            {
+                LOG.info("Job requires atomic operation for all records. And there was error in processing => Error as status");
+                throw Throwables.propagate(new DataException("Some records are not properly processed at MailChimp. See log for detail"));
+            }
             return Exec.newTaskReport().set("pushed", totalCount);
         }
         catch (JsonProcessingException jpe) {
@@ -304,6 +310,7 @@ public class MailChimpRecordBuffer
                  records.size(), reportResponse.getTotalCreated(),
                  reportResponse.getTotalUpdated(),
                  reportResponse.getErrorCount(), System.currentTimeMillis() - startTime);
+        errorCount += reportResponse.getErrors().size();
         mailChimpClient.handleErrors(reportResponse.getErrors());
 
         mailChimpClient.avoidFloodAPI("Process next request", task.getSleepBetweenRequestsMillis());

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
@@ -131,8 +131,7 @@ public class MailChimpRecordBuffer
                 duplicatedRecords = new ArrayList<>();
             }
             // When atomic upsert is true, client expects all records are done properly.
-            if(task.getAtomicUpsert() && errorCount > 0)
-            {
+            if (task.getAtomicUpsert() && errorCount > 0) {
                 LOG.info("Job requires atomic operation for all records. And there were {} errors in processing => Error as job's status", errorCount);
                 throw Throwables.propagate(new DataException("Some records are not properly processed at MailChimp. See log for detail"));
             }

--- a/src/test/java/org/embulk/output/mailchimp/TestMailChimpOutputPlugin.java
+++ b/src/test/java/org/embulk/output/mailchimp/TestMailChimpOutputPlugin.java
@@ -12,7 +12,6 @@ import org.embulk.config.ConfigSource;
 import org.embulk.config.ModelManager;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
-import org.embulk.spi.DataException;
 import org.embulk.spi.Exec;
 import org.embulk.spi.OutputPlugin;
 import org.embulk.spi.Schema;

--- a/src/test/java/org/embulk/output/mailchimp/TestMailChimpOutputPlugin.java
+++ b/src/test/java/org/embulk/output/mailchimp/TestMailChimpOutputPlugin.java
@@ -12,6 +12,7 @@ import org.embulk.config.ConfigSource;
 import org.embulk.config.ModelManager;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
+import org.embulk.spi.DataException;
 import org.embulk.spi.Exec;
 import org.embulk.spi.OutputPlugin;
 import org.embulk.spi.Schema;
@@ -96,6 +97,12 @@ public class TestMailChimpOutputPlugin
     public void test_config_invalidWithEmptyListId()
     {
         ConfigSource config = baseConfig.set("list_id", "");
+        doSetUpSchemaAndRun(config, plugin);
+    }
+    @Test(expected = ConfigException.class)
+    public void test_config_atomicUpsert()
+    {
+        ConfigSource config = baseConfig.set("atomic_upsert", true);
         doSetUpSchemaAndRun(config, plugin);
     }
 


### PR DESCRIPTION
We are adding new option atomic_upsert. The new option will allow:  
  - When true, job status will be false when there is an error happened at Mailchimp API.
  - When false, job status is true when there even error. Client will need to check log for error detail.
