### PR TITLE
Fix crashes on certain grouping configurations

### DIFF
--- a/src/main/java/org/embulk/output/mailchimp/MailChimpClient.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpClient.java
@@ -190,7 +190,7 @@ public class MailChimpClient
             Set<String> categoryNames = new HashSet<>(categories.keySet());
             if (!columnNames.containsAll(categoryNames)) {
                 categoryNames.removeAll(columnNames);
-                LOG.warn("Data column for category '{}' could not be found", on(", ").join(categoryNames));
+                LOG.warn("Data schema doesn't contain the task's grouping column", on(", ").join(categoryNames));
             }
 
             return categories;

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpClient.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpClient.java
@@ -172,6 +172,12 @@ public class MailChimpClient
                 }
 
                 for (CategoriesResponse categoriesResponse : allCategoriesResponse) {
+                    // Skip fetching interests if this category isn't specifed in the task's grouping column.
+                    // Assume the grouping columns are always in lower case (like `availableCategories` did)
+                    if (!interestCategoryNames.contains(categoriesResponse.getTitle().toLowerCase())) {
+                        continue;
+                    }
+
                     String detailPath = MessageFormat.format("/lists/{0}/interest-categories/{1}/interests",
                                                              task.getListId(),
                                                              categoriesResponse.getId());

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpClient.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpClient.java
@@ -121,7 +121,6 @@ public class MailChimpClient
     {
         try (MailChimpRetryable retryable = new MailChimpRetryable(task)) {
             Map<String, Map<String, InterestResponse>> categories = new HashMap<>();
-            List<String> taskGroupingColumns = task.getGroupingColumns().get();
             if (task.getGroupingColumns().isPresent() && !task.getGroupingColumns().get().isEmpty()) {
                 int count = 100;
                 int offset = 0;
@@ -129,6 +128,7 @@ public class MailChimpClient
                 boolean hasMore = true;
                 JsonNode response;
                 List<CategoriesResponse> allCategoriesResponse = new ArrayList<>();
+                List<String> taskGroupingColumns = task.getGroupingColumns().get();
 
                 while (hasMore) {
                     String path = MessageFormat.format("/lists/{0}/interest-categories?count={1}&offset={2}",
@@ -188,16 +188,15 @@ public class MailChimpClient
                     categories.put(categoriesResponse.getTitle().toLowerCase(),
                                    convertInterestCategoryToMap(interestsResponse.getInterests()));
                 }
-            }
 
-            // Warn if schema doesn't have the task's grouping column
-            Set<String> columnNames = caseInsensitiveColumnNames(schema);
-            Set<String> groupNames = new HashSet<>(taskGroupingColumns);
-            groupNames.removeAll(columnNames);
-            if (groupNames.size() > 0) {
-                LOG.warn("Data schema doesn't contain the task's grouping column(s): {}", on(", ").join(groupNames));
+                // Warn if schema doesn't have the task's grouping column
+                Set<String> columnNames = caseInsensitiveColumnNames(schema);
+                Set<String> groupNames = new HashSet<>(taskGroupingColumns);
+                groupNames.removeAll(columnNames);
+                if (groupNames.size() > 0) {
+                    LOG.warn("Data schema doesn't contain the task's grouping column(s): {}", on(", ").join(groupNames));
+                }
             }
-
             return categories;
         }
     }

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
@@ -175,7 +175,7 @@ public class MailChimpRecordBuffer
         if (categories == null) {
             categories = mailChimpClient.extractInterestCategoriesByGroupNames(task);
 
-            Set<String> categoriesNames = categories.keySet();
+            Set<String> categoriesNames = new HashSet<>(categories.keySet());
             Set<String> columnNames = caseInsensitiveColumnNames();
             if (!columnNames.containsAll(categoriesNames)) {
                 categoriesNames.removeAll(columnNames);

--- a/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpRecordBuffer.java
@@ -26,8 +26,6 @@ import org.embulk.spi.Exec;
 import org.embulk.spi.Schema;
 import org.slf4j.Logger;
 
-import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,9 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.TreeSet;
 
-import static com.google.common.base.Joiner.on;
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
 import static java.lang.String.format;
 import static org.embulk.output.mailchimp.MailChimpOutputPluginDelegate.PluginTask;
@@ -173,14 +169,7 @@ public class MailChimpRecordBuffer
         // Should loop the names and get the id of interest categories.
         // The reason why we put categories validation here because we can not share data between instance.
         if (categories == null) {
-            categories = mailChimpClient.extractInterestCategoriesByGroupNames(task);
-
-            Set<String> categoriesNames = new HashSet<>(categories.keySet());
-            Set<String> columnNames = caseInsensitiveColumnNames();
-            if (!columnNames.containsAll(categoriesNames)) {
-                categoriesNames.removeAll(columnNames);
-                LOG.warn("Data column for category '{}' could not be found", on(", ").join(categoriesNames));
-            }
+            categories = mailChimpClient.extractInterestCategoriesByGroupNames(task, schema);
         }
 
         // Extract merge fields detail
@@ -358,22 +347,5 @@ public class MailChimpRecordBuffer
                 mailChimpClient.handleErrors(reportResponse.getErrors());
             }
         }
-    }
-
-    private Set<String> caseInsensitiveColumnNames()
-    {
-        Set<String> columns = new TreeSet<>(CASE_INSENSITIVE_ORDER);
-        columns.addAll(FluentIterable
-                .from(schema.getColumns())
-                .transform(new Function<Column, String>() {
-                    @Nullable
-                    @Override
-                    public String apply(@Nullable Column col)
-                    {
-                        return col.getName();
-                    }
-                })
-                .toSet());
-        return columns;
     }
 }

--- a/src/main/java/org/embulk/output/mailchimp/helper/MailChimpHelper.java
+++ b/src/main/java/org/embulk/output/mailchimp/helper/MailChimpHelper.java
@@ -9,17 +9,23 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import org.embulk.output.mailchimp.model.AddressMergeFieldAttribute;
+import org.embulk.spi.Column;
+import org.embulk.spi.Schema;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
+import static java.lang.String.CASE_INSENSITIVE_ORDER;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -141,5 +147,22 @@ public final class MailChimpHelper
             }
         }
         return Optional.absent();
+    }
+
+    public static Set<String> caseInsensitiveColumnNames(Schema schema)
+    {
+        Set<String> columns = new TreeSet<>(CASE_INSENSITIVE_ORDER);
+        columns.addAll(FluentIterable
+                .from(schema.getColumns())
+                .transform(new Function<Column, String>() {
+                    @Nullable
+                    @Override
+                    public String apply(@Nullable Column col)
+                    {
+                        return col.getName();
+                    }
+                })
+                .toSet());
+        return columns;
     }
 }

--- a/src/main/java/org/embulk/output/mailchimp/helper/MailChimpHelper.java
+++ b/src/main/java/org/embulk/output/mailchimp/helper/MailChimpHelper.java
@@ -155,9 +155,8 @@ public final class MailChimpHelper
         columns.addAll(FluentIterable
                 .from(schema.getColumns())
                 .transform(new Function<Column, String>() {
-                    @Nullable
                     @Override
-                    public String apply(@Nullable Column col)
+                    public String apply(Column col)
                     {
                         return col.getName();
                     }

--- a/src/test/java/org/embulk/output/mailchimp/TestMailChimpHelper.java
+++ b/src/test/java/org/embulk/output/mailchimp/TestMailChimpHelper.java
@@ -4,15 +4,20 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import org.embulk.output.mailchimp.helper.MailChimpHelper;
 import org.embulk.output.mailchimp.model.AddressMergeFieldAttribute;
+import org.embulk.spi.Column;
+import org.embulk.spi.Schema;
+import org.embulk.spi.type.Types;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.embulk.output.mailchimp.helper.MailChimpHelper.caseInsensitiveColumnNames;
 import static org.embulk.output.mailchimp.helper.MailChimpHelper.containsCaseInsensitive;
 import static org.embulk.output.mailchimp.helper.MailChimpHelper.extractMemberStatus;
 import static org.embulk.output.mailchimp.helper.MailChimpHelper.maskEmail;
@@ -94,5 +99,13 @@ public class TestMailChimpHelper
         String expect = "{\"addr1\":\"1234\",\"addr2\":\"\",\"city\":\"mountain view\",\"state\":\"CA\",\"zip\":\"95869\",\"country\":\"US\"}";
         assertEquals("Should be JSON", ObjectNode.class, orderJsonNode(toJsonNode(given), attributes).getClass());
         assertEquals("Should be match", expect, orderJsonNode(toJsonNode(given), attributes).toString());
+    }
+
+    @Test
+    public void test_caseInsensitiveColumnNames()
+    {
+        Schema schema = new Schema(ImmutableList.of(
+                new Column(0, "InCONSisTENT", Types.LONG)));
+        assertTrue(caseInsensitiveColumnNames(schema).contains("inConsIstent"));
     }
 }


### PR DESCRIPTION
This bug is a rookie mistake I made on v0.3.28 release, due to a grouping/category entry is unintentionally removed while filtering for mismatches between task's grouping configuration and data columns:
https://github.com/treasure-data/embulk-output-mailchimp/commit/48b41685fcaa8ffa98242e213242a6cc2a1881b2#diff-5dd4e665f9c2ba8bfdfcefd12be11b25R179 ({{keySet()}} apparently returns a view, not a copy).