### PR TITLE
Refactor: a bit more consistent naming

### DIFF
--- a/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/mailchimp/MailChimpOutputPluginDelegate.java
@@ -39,17 +39,17 @@ public class MailChimpOutputPluginDelegate
     public interface PluginTask
             extends RestClientOutputTaskBase
     {
-        @Config("maximum_retries")
+        @Config("retry_limit")
         @ConfigDefault("6")
-        int getMaximumRetries();
+        int getRetryLimit();
 
-        @Config("initial_retry_interval_millis")
+        @Config("retry_initial_wait_msec")
         @ConfigDefault("1000")
-        int getInitialRetryIntervalMillis();
+        int getRetryInitialWaitMSec();
 
-        @Config("maximum_retry_interval_millis")
+        @Config("max_retry_wait_msec")
         @ConfigDefault("32000")
-        int getMaximumRetryIntervalMillis();
+        int getMaxRetryWaitMSec();
 
         @Config("timeout_millis")
         @ConfigDefault("60000")

--- a/src/main/java/org/embulk/output/mailchimp/helper/MailChimpRetryable.java
+++ b/src/main/java/org/embulk/output/mailchimp/helper/MailChimpRetryable.java
@@ -44,9 +44,9 @@ public class MailChimpRetryable implements AutoCloseable
 
     public MailChimpRetryable(final PluginTask pluginTask)
     {
-        this.retryHelper = new Jetty92RetryHelper(pluginTask.getMaximumRetries(),
-                                                  pluginTask.getInitialRetryIntervalMillis(),
-                                                  pluginTask.getMaximumRetryIntervalMillis(),
+        this.retryHelper = new Jetty92RetryHelper(pluginTask.getRetryLimit(),
+                                                  pluginTask.getRetryInitialWaitMSec(),
+                                                  pluginTask.getMaxRetryWaitMSec(),
                                                   new DefaultJetty92ClientCreator(pluginTask.getTimeoutMillis(),
                                                                                   pluginTask.getTimeoutMillis()));
         this.pluginTask = pluginTask;


### PR DESCRIPTION
Rename some options: 
maximum_retries
initial_retry_interval_millis
maximum_retry_interval_millis

To following: 
retry_limit
retry_initial_wait_msec
max_retry_wait_msec